### PR TITLE
Adjusted template to support css originating from presentations repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY present/prompt.sh /bin/prompt
 # default presentation repository
 # Note: Switching to 'ARG' as soon as the Docker Hub stack supports '--build-args'
 #RUN git clone https://github.com/docker-training/presentations /opt/revealjs/src
-ADD presentations /opt/revealjs/src
+#ADD presentations /opt/revealjs/src
+RUN mkdir /opt/revealjs/src
 
 ENTRYPOINT ["/bin/prompt"]

--- a/present/templates/index.html
+++ b/present/templates/index.html
@@ -16,9 +16,9 @@
 
         <!-- css -->
         <link rel="stylesheet" href="css/reveal.css">
-        <link rel="stylesheet" href="css/sd_custom.css">
-        <link rel="stylesheet" href="css/theme/docker.css" id="theme">
-        <link rel="stylesheet" href="lib/css/docker-code.css">
+        <link rel="stylesheet" href="src/css/sd_custom.css">
+        <link rel="stylesheet" href="src/css/docker.css" id="theme">
+        <link rel="stylesheet" href="src/css/docker-code.css">
 
         <!-- Printing and PDF exports -->
         <script>

--- a/present/templates/index.html
+++ b/present/templates/index.html
@@ -16,8 +16,8 @@
 
         <!-- css -->
         <link rel="stylesheet" href="css/reveal.css">
-        <link rel="stylesheet" href="src/css/sd_custom.css">
         <link rel="stylesheet" href="src/css/docker.css" id="theme">
+        <link rel="stylesheet" href="src/css/sd_custom.css">
         <link rel="stylesheet" href="src/css/docker-code.css">
 
         <!-- Printing and PDF exports -->


### PR DESCRIPTION
With this new template we can keep the CSS (and fonts) local to the `presentation` repo.
See PR: https://github.com/docker-training/presentations/pull/236
I also changed the order in which the CSS files are loaded. The custom CSS is now last.
This needs to be merged first