### PR TITLE
added flag to pick presentation at container launch w/o interactive p…

### DIFF
--- a/present/prompt.sh
+++ b/present/prompt.sh
@@ -13,6 +13,7 @@ docker-present
 
     -h    Display help
     -p    Specify port (required)
+    -x    Default presentation name
 
   Usage:
 
@@ -24,17 +25,31 @@ EOF
 exit 1
 }
 
+function run() {
+
+  printf "\nAttempting to start presentation '$1' on port: $2 ...\n"
+  docker run -d --expose=$2 \
+             -p $2:$2 \
+             --entrypoint="$(pwd)/present.py" \
+             --volumes-from ${HOSTNAME} \
+             training/docker-present:dev $1 $2
+  exit 1
+}
+
 # display usage when executed without args
 if [ $# -eq 0 ]; then usage; fi
 
 # process args
-while getopts ":p:h" opt; do
+while getopts ":p:hx:" opt; do
   case "${opt}" in
     p)
       PORT=${OPTARG}
       ;;
     h)
       usage
+      ;;
+    x)
+      EX=${OPTARG}
       ;;
     \?)
       echo "Invalid option: -${OPTARG}" >&2
@@ -62,18 +77,16 @@ printf "=======================\n\n"
 find ${DIR} -printf "%f:@" -exec head -qn1 {} \; | column -t -s@ | sed 's/# //g'
 printf "\n---\n\n"
 
+if [ -n "$EX" ]; then
+  run ${EX} ${PORT}
+fi
+
 OLD_IFS=${IFS}
 IFS=":"
 PS3=$'\nEnter selection: '
 select PRES in ${MENU}; do
   if [ -n "$PRES" ]; then
-
-    printf "\nAttempting to start presentation '${PRES}' on port: ${PORT} ...\n"
-    docker run -d --expose=${PORT} \
-               -p ${PORT}:${PORT} \
-               --entrypoint="$(pwd)/present.py" \
-               --volumes-from ${HOSTNAME} \
-               training/docker-present:dev ${PRES} ${PORT}
+    run ${PRES} ${PORT}
     exit 1
   fi
 done


### PR DESCRIPTION
`-x` flag when running container allows to choose presentation without an interactive prompt; ie `-x Docker-Fundamentals` will just launch fundamentals.

Why? I want to completely automate slide PDF generation, so I need to be able to start presentations from a bash script.