### PR TITLE
Adding ability to render modified material without restarting container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:2.7
-
-MAINTAINER Jerry Baker <jbaker@docker.com>
+LABEL maintainer "dougtoppin@gmail.com"
+LABEL org.label-schema.vcs-url="https://github.com/dougtoppin/docker-present"
+LABEL org.label-schema.description="Controller image for Docker training courses"
 
 # required packages
 RUN apt-get update && apt-get -y install \
@@ -30,6 +31,8 @@ COPY present/fonts /opt/revealjs/fonts/
 COPY present/images /opt/revealjs/images/
 COPY present/templates /opt/revealjs/templates
 COPY present/prompt.sh /bin/prompt
+COPY present/update.py /tmp/update.py
+COPY present/update.sh /tmp/update.sh
 
 # default presentation repository
 # Note: Switching to 'ARG' as soon as the Docker Hub stack supports '--build-args'

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Checking connectivity... done.
 kizbitz@docker:~/sandbox$ docker run -ti -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/mypresentations:/tmp/src training/docker-present -p 8000
 ```
 
+If you add or modify modules the changes can be displayed by running a script in the already running container as follows and refeshing your browser tab.
+
+```
+$ docker container exec CONTAINERID /tmp/update.sh class-name
+Updating presentation 'class-name' ...
+```
 
 ## Templates
 

--- a/present/prompt.sh
+++ b/present/prompt.sh
@@ -17,7 +17,7 @@ docker-present
 
   Usage:
 
-    docker run -ti -v /var/run/docker.sock:/var/run/docker.sock training/docker-present:dev -p <port>
+    docker run -ti -v /var/run/docker.sock:/var/run/docker.sock dougtoppin/docker-present -p <port>
 
     Note: Mounting the Docker socket is required.
 
@@ -32,7 +32,7 @@ function run() {
              -p $2:$2 \
              --entrypoint="$(pwd)/present.py" \
              --volumes-from ${HOSTNAME} \
-             training/docker-present:dev $1 $2
+             dougtoppin/docker-present $1 $2
   exit 1
 }
 

--- a/present/update.py
+++ b/present/update.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# regenerate presentation files for browser access and exit,
+# expects only a class-name argument
+
+import os
+import shutil
+import SimpleHTTPServer
+import SocketServer
+import sys
+
+
+BASE = '/opt/revealjs/'
+PRES = BASE + 'src/presentations'
+MODS = BASE + 'src/modules'
+TEMPLATE = BASE + 'templates/index.html'
+INDEX = BASE + 'index.html'
+SECTION = '''
+                <section data-markdown="src/modules/{0}/slides.md"
+                     data-separator="^\\n---\\n"
+                     data-separator-vertical="^\\n----\\n"
+                     data-separator-notes="^Note:"
+                     data-charset="iso-8859-15">
+                </section>
+'''
+
+
+def check_custom():
+    """Check and adjust for a custom repository"""
+    if os.path.exists('/tmp/src'):
+        shutil.rmtree(BASE + 'src')
+        shutil.copytree('/tmp/src', BASE + 'src')
+
+
+def create_html(answer):
+    """Create index.html"""
+
+    slides = ""
+    with open(os.path.join(PRES, answer)) as mods:
+        modules = mods.readlines()
+    for module in modules:
+        if not module.strip() or module.startswith("#"):
+            continue
+        module = module.strip()
+        if os.path.exists(os.path.join(MODS, module, "slides.html")):
+            with open (os.path.join(MODS, module, 'slides.html'), "r") as f:
+                html=f.read()
+                slides += html
+        else:
+            slides += SECTION.format(module)
+
+
+    with open (TEMPLATE, "r") as t:
+        template=t.read().replace('---modules---', slides)
+    with open(INDEX, "w") as html:
+        html.write(template)
+
+
+def adjust_image_paths(answer):
+    """Adjust image paths in slides.md
+       When running the web server the paths are relative to index.html instead of the markdown file
+    """
+
+    with open(os.path.join(PRES, answer)) as mods:
+        modules = mods.readlines()
+    for module in modules:
+        if not module.strip() or module.startswith("#"):
+            continue
+        module = module.strip()
+        if os.path.exists(os.path.join(MODS, module, 'slides.html')):
+            current = 'slides.html'
+        else:
+            current = 'slides.md'
+        with open(os.path.join(MODS, module, current), 'r') as slides:
+            file=slides.read().replace('images/', 'src/modules/' + module + '/images/')
+        with open(os.path.join(MODS, module, current), 'w') as slides:
+            slides.write(file)
+
+
+
+if __name__ == '__main__':
+
+    presentation = sys.argv[1]
+
+    check_custom()
+    adjust_image_paths(presentation)
+
+    create_html(presentation)
+
+    print "Updating presentation '{0}' ...".format(presentation)
+

--- a/present/update.sh
+++ b/present/update.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# update material files in running present container,
+# this is intended to assist in presentation material development by
+# allowing the running present container to render updated files without
+# having to be restarted,
+# when invoked this will copy all module files into the revealjs directory,
+# a browser refresh will show the updated material
+
+function usage() {
+cat <<EOF
+    Usage:
+      /tmp/prompt.sh class-name
+
+    Example:  /tmp/prompt.sh class-name
+
+EOF
+exit 1
+}
+
+UPDATESCRIPT=/tmp/update.py
+MODULESDIR=/tmp/src/modules/
+
+# we are expecting only the presentation material directory as an argument
+if [ $# -ne 1 ]; then usage; fi
+
+if [ ! -d $MODULESDIR ]
+then
+    echo "error, $MODULESDIR not found"
+    exit 1
+fi
+
+# copy all module files to the rendering directory
+cp -R $MODULESDIR /opt/revealjs/src/
+
+# invoke the update script to regenerate the presentation
+$UPDATESCRIPT $1
+


### PR DESCRIPTION
Suggested fix for issue #22 
I added a script that copies the modules/ files into the revealjs directory.
The script is invoked in the already running present container with the class-name as an argument.
The script runs a python script which performs a subset of the same actions as present.py and then exits.
I performed the following tests to confirm the new function
- modify class material and invoke script with class name, confirmed that changes appeared
- invoked script without class argument, confirmed error returned
- invoked script with class argument that did not match a class, confirmed error returned
- confirmed that present container runs as usual

Note that the maintainer and repo names should be changed back to match the original values if the merge is accepted.
