### PR TITLE
tombstone source dir before writing over

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ COPY present/templates /opt/revealjs/templates
 COPY present/prompt.sh /bin/prompt
 
 # default presentation repository
+RUN rm -rf /opt/revealjs/src
 ADD presentations /opt/revealjs/src
 
 ENTRYPOINT ["/bin/prompt"]


### PR DESCRIPTION
otherwise deleted files show through, especially annoying when scrapping old presentations that then come back from the dead.